### PR TITLE
Add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+
+go:
+  - "1.5.3"
+  - "1.11"
+  - master
+
+script:
+  - make test
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.DEFAULT_GOAL := test
+
+# Clean up
+clean:
+	@rm -fR ./cover.*
+.PHONY: clean
+
+# Run tests and generates html coverage file
+cover: test
+	@go tool cover -html=./coverage.text -o ./coverage.html
+.PHONY: cover
+
+# Run tests
+test:
+	@go test -v -race -coverprofile=./coverage.text -covermode=atomic $(shell go list ./...)
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 GoDisco: Discourse REST API Client
 ===============================
+[![Build Status](https://img.shields.io/travis/FrenchBen/godisco/master.svg?style=flat-square)](https://travis-ci.org/FrenchBen/godisco)
+[![Codecov branch](https://img.shields.io/codecov/c/github/FrenchBen/godisco/master.svg?style=flat-square)](https://codecov.io/gh/FrenchBen/godisco)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=flat-square)](https://godoc.org/github.com/FrenchBen/godisco)
+[![Go Report Card](https://goreportcard.com/badge/github.com/FrenchBen/godisco?style=flat-square)](https://goreportcard.com/report/github.com/FrenchBen/godisco)
+
 <p align="center">
   <a href="http://golang.org" target="_blank"><img alt="Go package" src="https://golang.org/doc/gopher/pencil/gopherhat.jpg" width="20%" /></a>
   <a href="https://www.discourse.org/" target="_blank"><img src="https://pbs.twimg.com/profile_images/3264780953/6c9a2cd7bb2efcb4c53d32900e52c8ac_400x400.png" alt="Discourse Logo"/></a>


### PR DESCRIPTION
In order to run tests automatically, the travis-ci file for running
tests and lint.

Inside the readme contains the info about coverage, travis build,
godocs and others badges.

> It's necessary to enable the travis-ci and codecov.